### PR TITLE
Fix an error in the docs that left me confused for a good half an hour

### DIFF
--- a/docs/Kiwi.md
+++ b/docs/Kiwi.md
@@ -28,7 +28,7 @@ solver.addEditVariable(width, kiwi.Strength.strong)
 // Create a variable calculated through a constraint
 const centerX = new kiwi.Variable()
 const expr = new kiwi.Expression([-1, centerX], left, [0.5, width])
-solver.addConstraint(new kiwi.Constraint(expr, kiwi.Operator.Eq, kiwi.Strength.required))
+solver.addConstraint(new kiwi.Constraint(expr, kiwi.Operator.Eq, 0, kiwi.Strength.required))
 
 // Suggest some values to the solver
 solver.suggestValue(left, 0)

--- a/src/solver.ts
+++ b/src/solver.ts
@@ -14,7 +14,7 @@ export class Solver {
 	 * @type {number} - The max number of solver iterations before an error
 	 * is thrown, in order to prevent infinite iteration. Default: `10,000`.
 	 */
-	public maxIterations = 1000
+	public maxIterations = 10000
 
 	/**
 	 * Construct a new Solver.


### PR DESCRIPTION
An argument is missing in the `Constraint` constructor, which leaves the strength to be interpreted as the rhs of the constraint. It left me bamboozled for a while until I noticed that difference between the API docs and the CodePen demo.

Also, the docs say the default `maxIterations` is 10,000. I changed the number to match the docs (perhaps I should have changed the docs?).

I hope this is OK. Have a nice day!